### PR TITLE
Update co-owner username

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,6 @@
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a 
 # pull request.
-*       @bumblefudge @celehner @oed
+*       @bumblefudge @clehner @oed
 
 # See CODEOWNERS syntax here: https://help.github.com/articles/about-codeowners/#codeowners-syntax

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Draft spec [here](https://github.com/spruceid/ssi/blob/383cb7b3e4e8dace1c527585f
 ## List Owners
 
 Juan Caballero, Spruce, @bumblefudge 
-Charles Lehner, Spruce, @celehner
+Charles Lehner, Spruce, @clehner
 Joel Thorstensson, 3Box/Ceramic, @oed
 
 ## Work Item Questions


### PR DESCRIPTION
https://github.com/w3c-ccg/community/issues/200 used "celehner", but it should be "clehner".