### PR TITLE
Add latest version link

### DIFF
--- a/did-pkh-method-draft.md
+++ b/did-pkh-method-draft.md
@@ -1,7 +1,8 @@
 # did:pkh Method Specification
 
-Authors: Wayne Chang, Charles Lehner, Juan Caballero, Joel Thorstensson
-Status: Draft
+**Authors**: Wayne Chang, Charles Lehner, Juan Caballero, Joel Thorstensson  
+**Latest version**: https://github.com/w3c-ccg/did-pkh/blob/main/did-pkh-method-draft.md  
+**Status**: Draft  
 
 ## Introduction
 


### PR DESCRIPTION
Add link to document in this repo. This facilitates sharing a link to the document at a particular commit hash, while having an easy way for the document snapshot to point to the latest draft version.

Also, stylize the header by bolding the names, to enhance readabilit; and fix the line wrapping.