### PR TITLE
Change meeting to Wednesdays 12:15pm Eastern

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ We would like to open up the design process for the did:pkh [**method specificat
 
 ## Meetings
 
-Regular meetings for this CCG work item will be held every four weeks on Thursdays, from March 24th, 2022, onwards, at [1.30PM Eastern Time](https://www.timeanddate.com/worldclock/), on a
+Regular meetings for this CCG work item will be held every four weeks on Wednesdays, from April 20th, 2022, onwards, at [12.15PM Eastern Time](https://www.timeanddate.com/worldclock/fixedtime.html?iso=2022-04-20T12:15:00&p1=179), on a
 [workitem-specific jitsi room](https://meet.w3c-ccg.org/didpkh) hosted by the CCG.  Minutes will be published 
 in [the meetings directory](meetings/) here in the repo.  
 


### PR DESCRIPTION
A new time is needed, that does not conflict with other CCG calls or DIF events, as mentioned on our previous call (#29).